### PR TITLE
Updating README to reflect Imagemagick dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Take the 2x images and generate retina and regular versions
 
 ## Getting Started
-This plugin requires Grunt `~0.4.1`
+This plugin requires Grunt `~0.4.1` as well as [Imagemagick](http://www.imagemagick.org/).
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 


### PR DESCRIPTION
I wanted to use this plugin, as it solves my use case perfectly, however it took me a few hours of googling "spawn" error to figure out that Imagemagick is required on the system. This simple clarification in the README will hopefully save future devs frustration.
